### PR TITLE
Alterado nome do bucket

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    bucket = "techchallenge-terraform"
-    key    = "estado/terraform.tfstate"
+    bucket = "orion-techchallenge"
+    key    = "terraform.tfstate"
     region = "us-east-1"
   }
 }


### PR DESCRIPTION
- Tive que criar o bucket do s3 na mao ....

O correto seria deixar o terraform criar o bucket numa versao "bootstrap"
E depois fazer as alteracoes para usar o bucket criado como referencia